### PR TITLE
Fix bento amp-audio unit test

### DIFF
--- a/extensions/amp-audio/1.0/test/test-amp-audio.js
+++ b/extensions/amp-audio/1.0/test/test-amp-audio.js
@@ -29,6 +29,13 @@ describes.realWin(
       toggleExperiment(win, 'bento-audio', true, true);
     });
 
+    afterEach(async () => {
+      // Clean up the child elements that are appended in the body in attachAndRun method.
+      while (doc.body.firstChild) {
+        doc.body.removeChild(doc.body.firstChild);
+      }
+    });
+
     /**
      * Wait for iframe to be mounted
      */


### PR DESCRIPTION
This PR fixes the following unit test error for amp-audio bento component,
```
● "before each" hook for "should not preload audio"
   Error: Uncaught TypeError: Cannot read property 'navigator' of null (/tmp/fa9cb47f0e6e55ae8e38a8c8e6109aef-bundle.js:46007)
● "after each" hook for "should not preload audio"
   TypeError: Cannot read property 'customElements' of undefined
      at AmpFixture2.teardown (home/circleci/project/testing/describes.js:895:13)
      at _callee$ (home/circleci/project/testing/describes.js:336:29)
      at tryCatch (home/circleci/project/node_modules/fetch-mock/es5/client-bundle.js:1291:52)
      at Generator.invoke [as _invoke] (home/circleci/project/node_modules/fetch-mock/es5/client-bundle.js:1521:34)
      at Generator.next (home/circleci/project/node_modules/fetch-mock/es5/client-bundle.js:1346:33)
      at asyncGeneratorStep (home/circleci/project/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:20)
      at _next (home/circleci/project/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
      at http://localhost:9876/home/circleci/project/node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
      at new Promise (<anonymous>)
      at Context.<anonymous> (home/circleci/project/node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12)
```